### PR TITLE
增加商品限购功能并解决已删除商品可以直接从URL购买的问题

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -828,7 +828,7 @@ class UserController extends Controller
         $user = $request->session()->get('user');
 
         if ($request->method() == 'POST') {
-            $goods = Goods::query()->with(['label'])->where('id', $goods_id)->where('status', 1)->first();
+            $goods = Goods::query()->with(['label'])->where('id', $goods_id)->where('is_del', 0)->where('status', 1)->first();
             if (empty($goods)) {
                 return Response::json(['status' => 'fail', 'data' => '', 'message' => '支付失败：商品或服务已下架']);
             }
@@ -970,7 +970,7 @@ class UserController extends Controller
                 return Response::json(['status' => 'fail', 'data' => '', 'message' => '支付失败：' . $e->getMessage()]);
             }
         } else {
-            $goods = Goods::query()->where('id', $goods_id)->where('status', 1)->first();
+            $goods = Goods::query()->where('id', $goods_id)->where('is_del', 0)->where('status', 1)->first();
             if (empty($goods)) {
                 return Redirect::to('user/goodsList');
             }

--- a/database/seeds/ConfigTableSeeder.php
+++ b/database/seeds/ConfigTableSeeder.php
@@ -65,5 +65,6 @@ class ConfigTableSeeder extends Seeder
         DB::insert("INSERT INTO `config` VALUES ('52', 'youzan_client_secret', '');");
         DB::insert("INSERT INTO `config` VALUES ('53', 'kdt_id', '');");
         DB::insert("INSERT INTO `config` VALUES ('54', 'initial_labels_for_user', '');");
+        DB::insert("INSERT INTO `config` VALUES ('58', 'goods_purchase_limit_strategy', 'none');");
     }
 }

--- a/resources/views/admin/system.blade.php
+++ b/resources/views/admin/system.blade.php
@@ -292,6 +292,34 @@
                                                             </div>
                                                         </div>
                                                     </div>
+                                                    <div class="form-group">
+                                                        <div class="col-md-6">
+                                                            <label for="goods_purchase_limit_strategy" class="col-md-3 control-label">商品限购</label>
+                                                            <div class="col-md-9">
+                                                                <select id="goods_purchase_limit_strategy" class="form-control select2" name="goods_purchase_limit_strategy">
+                                                                    <option value="none"
+                                                                        @if ($goods_purchase_limit_strategy == 'none')
+                                                                        selected
+                                                                        @endif
+                                                                    >不限制</option>
+                                                                    <option value="free"
+                                                                        @if ($goods_purchase_limit_strategy == 'free')
+                                                                        selected
+                                                                        @endif
+                                                                    >仅限免费商品</option>
+                                                                    <option value="all"
+                                                                        @if ($goods_purchase_limit_strategy == 'all')
+                                                                        selected
+                                                                        @endif
+                                                                    >限全部商品</option>
+                                                                </select>
+                                                                <span class="help-block"> 是否限制用户重复购买商品，限制后用户不可重复购买已购买的、尚在有效期的商品 </span>
+                                                            </div>
+                                                        </div>
+                                                        <div class="col-md-6">
+                                                            &nbsp;
+                                                        </div>
+                                                    </div>
                                                 </div>
                                             </form>
                                         </div>
@@ -1230,6 +1258,17 @@
                     }
                 });
             });
+        });
+
+        $("#goods_purchase_limit_strategy").change(function() {
+            var strategy = $(this).val();
+            $.post("{{url('admin/setConfig')}}", {_token:'{{csrf_token()}}', name:'goods_purchase_limit_strategy', value: strategy}, function (ret) {
+                layer.msg(ret.message, {time:1000}, function() {
+                    if (ret.status == 'fail') {
+                        window.location.reload();
+                    }
+                });
+            }); 
         });
 
         // 设置注册时默认有效期

--- a/sql/db.sql
+++ b/sql/db.sql
@@ -328,6 +328,7 @@ INSERT INTO `config` VALUES ('54', 'initial_labels_for_user', '');
 INSERT INTO `config` VALUES ('55', 'website_analytics', '');
 INSERT INTO `config` VALUES ('56', 'website_customer_service', '');
 INSERT INTO `config` VALUES ('57', 'register_ip_limit', 5);
+INSERT INTO `config` VALUES ('58', 'goods_purchase_limit_strategy', 'none');
 
 
 -- ----------------------------

--- a/sql/update/20180609.sql
+++ b/sql/update/20180609.sql
@@ -1,0 +1,2 @@
+-- 加入限购配置
+INSERT INTO `config` VALUES ('58', 'goods_purchase_limit_strategy', 'none');


### PR DESCRIPTION
1. 解决未下架直接删除的商品可以直接通过购买链接购买的问题
2. 增加商品限购功能，功能可在系统设置->扩展设置中进行设置

    设置限制购买后，对于同一个商品，如果用户已经购买并且还未到期，则不可再重复购买

    设置共有三个选项：
- 不限制：默认，与之前的逻辑相同
- 仅限制免费商品：仅价格为0的商品限制购买
- 限全部商品：所有商品均限购