### PR TITLE
修复节点自定义排序不生效的问题

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -87,6 +87,7 @@ class UserController extends Controller
             ->whereIn('ss_node_label.label_id', $userLabelIds)
             ->where('ss_node.status', 1)
             ->groupBy('ss_node.id')
+            ->orderBy('sort', 'desc')
             ->get();
 
         foreach ($nodeList as &$node) {


### PR DESCRIPTION
后台可设置sort值，值越大排越前。但设置后不生效，因为少了这一句。