### PR TITLE
修复因流量超限被封禁的账户不会清空流量的BUG

### DIFF
--- a/app/Console/Commands/AutoJob.php
+++ b/app/Console/Commands/AutoJob.php
@@ -170,13 +170,18 @@ class AutoJob extends Command
         }
     }
 
-    // 自动移除被封禁代理的账号的标签（临时封禁不移除）
+    // 自动清空过期的账号的标签和流量（临时封禁不移除）
     private function removeUserLabels()
     {
-        $userList = User::query()->where('enable', 0)->where('ban_time', 0)->get();
+        $userList = User::query()->where('enable', 0)->where('ban_time', 0)->where('expire_time', '<=', date('Y-m-d'))->get();
         if (!$userList->isEmpty()) {
             foreach ($userList as $user) {
                 UserLabel::query()->where('user_id', $user->id)->delete();
+                User::query()->where('id', $user->id)->update([
+                    'u'               => 0,
+                    'd'               => 0,
+                    'transfer_enable' => 0,
+                ]);
             }
         }
     }

--- a/app/Console/Commands/AutoJob.php
+++ b/app/Console/Commands/AutoJob.php
@@ -180,7 +180,7 @@ class AutoJob extends Command
                 User::query()->where('id', $user->id)->update([
                     'u'               => 0,
                     'd'               => 0,
-                    'transfer_enable' => 0,
+                    'transfer_enable' => 0
                 ]);
             }
         }


### PR DESCRIPTION
1.我发现流量超限的用户，即使账号过期了，流量（已用流量和可用流量）还是没清空。
2.但我们不能在他流量超限的时候清空，因为可能他套餐没用完。
3.而账号没过期，最好也不要清空标签，万一他有流量了（套餐重置了已用流量或者邀请返利了），这时解封账号，他会没有标签。