### PR TITLE
修正个人中心手机浏览时显示不对齐

### DIFF
--- a/resources/views/user/index.blade.php
+++ b/resources/views/user/index.blade.php
@@ -163,6 +163,9 @@
                                                             </span>
                                                             <ul class="mt-comment-actions" style="display: block;">
                                                                 <li>
+                                                                    <a class="btn btn-sm green btn-outline" data-toggle="modal" href="#txt_{{$node->id}}" > 查看配置信息 </a>
+                                                                </li>
+                                                                <li>
                                                                     <a class="btn btn-sm green btn-outline" data-toggle="modal" href="#link_{{$node->id}}"> <i class="fa fa-paper-plane"></i> </a>
                                                                 </li>
                                                                 <li>
@@ -182,7 +185,9 @@
                 </div>
                 @endif
             </div>
-            <div class="col-md-4" style="padding-left: 3px;">
+            </div>
+            <div class="row">
+            <div class="col-md-4">
                 <ul class="list-group">
                     @if($info['enable'])
                     <li class="list-group-item">
@@ -253,6 +258,7 @@
                 </ul>
             </div>
         </div>
+        
         <div id="charge_modal" class="modal fade" tabindex="-1" data-focus-on="input:first" data-keyboard="false">
             <div class="modal-dialog">
                 <div class="modal-content">

--- a/resources/views/user/replyTicket.blade.php
+++ b/resources/views/user/replyTicket.blade.php
@@ -152,25 +152,25 @@
                 }
             });
         }
-
+      
         // 回复工单
         function replyTicket() {
             var content = UE.getEditor('editor').getContent();
 
-            $.ajax({
-                type: "POST",
-                url: "{{url('replyTicket')}}",
-                async: true,
-                data: {_token:'{{csrf_token()}}', id:'{{$ticket->id}}', content:content},
-                dataType: 'json',
-                success: function (ret) {
+            if (content =="" || content == undefined) {
+                layer.alert('您未填写工单内容', {icon: 2, title:'提示'});
+                return false;
+            }
+            layer.confirm('确定回复工单？', {icon: 3, title:'提示'}, function(index) {
+                $.post("{{url('replyTicket')}}",{_token:'{{csrf_token()}}', id:'{{$ticket->id}}', content:content}, function(ret) {
                     layer.msg(ret.message, {time:1000}, function() {
                         if (ret.status == 'success') {
                             window.location.reload();
                         }
                     });
-                }
+                });
+                layer.close(index);
             });
-        }
+        }         
     </script>
 @endsection

--- a/resources/views/user/ticketList.blade.php
+++ b/resources/views/user/ticketList.blade.php
@@ -102,12 +102,12 @@
             var content = $("#content").val();
 
             if (title == '' || title == undefined) {
-                bootbox.alert('工单标题不能为空');
+                layer.alert('您未填写工单标题', {icon: 2, title:'提示'});
                 return false;
             }
 
             if (content == '' || content == undefined) {
-                bootbox.alert('工单内容不能为空');
+                layer.alert('您未填写工单内容', {icon: 2, title:'提示'});
                 return false;
             }
 


### PR DESCRIPTION
1.节点恢复查看文本配置信息.
2.修正提交工单时，标题和内容为空不弹出提示信息的Bug.
3.防止用户回复工单时连续提交相同内容。