### PR TITLE
fix CORS error in https

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -13,6 +13,10 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        if (env('APP_ENV') === 'production') {
+            \URL::forceScheme('https');
+        }
+
         //\Schema::defaultStringLength(191);
     }
 


### PR DESCRIPTION
在对ssrpanel设置了https后，如果不对返回reoute 转化为https. 会导致浏览器有CORS错误，导致没法做修改。因为在AppServiceProvider.php 增加在env=production进行全局ssl 转换。已测试通过。