### PR TITLE
fixed 批量生成接口 报错

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -310,7 +310,7 @@ class AdminController extends Controller
                 $user->save();
 
                 // 初始化默认标签
-                if (count(self::$systemConfig['initial_labels_for_user']) > 0) {
+                if (!empty(self::$systemConfig['initial_labels_for_user'])) {
                     $labels = explode(',', self::$systemConfig['initial_labels_for_user']);
                     $this->makeUserLabels($user->id, $labels);
                 }


### PR DESCRIPTION
报错信息如下：

> Warning: count(): Parameter must be an array or an object that implements Countable in … // PHP 7.2 起

自 PHP 7.2 起 对 count 函数参数类型加了限制，数组或者 `Countable` 对象，所以这里改成 !empty 更为合适并且兼容。