### PR TITLE
增加F2FPay自定义商品名选项，完善F2FPay设置注释，修复Kitsunebi不可用的问题

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -1436,7 +1436,7 @@ class AdminController extends Controller
                     "path" => $node->v2_path,
                     "tls"  => $node->v2_tls ? "tls" : ""
                 ];
-                $v2_scheme = 'vmess://' . base64url_encode(json_encode($v2_json));
+                $v2_scheme = 'vmess://' . base64url_encode(json_encode($v2_json,JSON_PRETTY_PRINT));
 
                 // 生成文本配置信息
                 $txt = "服务器：" . ($node->server ? $node->server : $node->ip) . "\r\n";

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -184,7 +184,7 @@ class PaymentController extends Controller
                     'return_raw'      => false
                 ], [
                     'body'     => '',
-                    'subject'  => '银鹭牛奶花生复合蛋白饮品（CAN370g）', // TODO：改为生成随机零售商品，比如：银鹭牛奶花生复合蛋白饮品（CAN370g）、晋江牛肉馆 - 外卖订单
+                    'subject'  => self::$systemConfig['f2fpay_subject_name'], 
                     'order_no' => $orderSn,
                     'amount'   => $amount,
                 ]);

--- a/app/Http/Controllers/SubscribeController.php
+++ b/app/Http/Controllers/SubscribeController.php
@@ -220,7 +220,7 @@ class SubscribeController extends Controller
                     "tls"  => $node['v2_tls'] ? "tls" : ""
                 ];
 
-                $scheme .= 'vmess://' . base64url_encode(json_encode($v2_json)) . "\n";
+                $scheme .= 'vmess://' . base64url_encode(json_encode($v2_json,JSON_PRETTY_PRINT)) . "\n";
             }
         }
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -214,7 +214,7 @@ class UserController extends Controller
                     "path" => $node->v2_path,
                     "tls"  => $node->v2_tls == 1 ? "tls" : ""
                 ];
-                $v2_scheme = 'vmess://' . base64url_encode(json_encode($v2_json));
+                $v2_scheme = 'vmess://' . base64url_encode(json_encode($v2_json,JSON_PRETTY_PRINT));
 
                 // 生成文本配置信息
                 $txt = "服务器：" . ($node->server ? $node->server : $node->ip) . "\r\n";

--- a/resources/views/admin/system.blade.php
+++ b/resources/views/admin/system.blade.php
@@ -963,6 +963,7 @@
                                                                         <button class="btn btn-success" type="button" onclick="setF2fpayAppId()">修改</button>
                                                                     </span>
                                                                 </div>
+                                                                <span class="help-block"> 即：APPID </span>
                                                             </div>
                                                         </div>
                                                     </div>
@@ -977,11 +978,12 @@
                                                                         <button class="btn btn-success" type="button" onclick="setF2fpayPrivateKey()">修改</button>
                                                                     </span>
                                                                 </div>
+                                                                <span class="help-block"> 即：rsa_private_key，不包括首尾格式 </span>
                                                             </div>
                                                         </div>
                                                         <div class="col-md-6 col-sm-6 col-xs-12">
                                                             <label for="alipay_public_key"
-                                                                   class="col-md-3 control-label">RSA公钥</label>
+                                                                   class="col-md-3 control-label">支付宝公钥</label>
                                                             <div class="col-md-9">
                                                                 <div class="input-group">
                                                                     <input class="form-control" type="text" name="f2fpay_public_key" value="{{$f2fpay_public_key}}" id="f2fpay_public_key"/>
@@ -989,6 +991,22 @@
                                                                     <button class="btn btn-success" type="button" onclick="setF2fpayPublicKey()">修改</button>
                                                                 </span>
                                                                 </div>
+                                                                <span class="help-block"> 注意不是RSA公钥 </span>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                    <div class="form-group">
+                                                        <div class="col-md-6 col-sm-6 col-xs-12">
+                                                            <label for="f2fpay_subject_name"
+                                                                   class="col-md-3 control-label">自定义商品名称</label>
+                                                            <div class="col-md-9">
+                                                                <div class="input-group">
+                                                                    <input class="form-control" type="text" name="f2fpay_subject_name" value="{{$f2fpay_subject_name}}" id="f2fpay_subject_name"/>
+                                                                    <span class="input-group-btn">
+                                                                        <button class="btn btn-success" type="button" onclick="setF2fpaySubjectName()">修改</button>
+                                                                    </span>
+                                                                </div>
+                                                                <span class="help-block"> 用于在用户支付宝客户端显示 </span>
                                                             </div>
                                                         </div>
                                                     </div>
@@ -2021,11 +2039,27 @@
             });
         }
 
-
         // 自动去除公钥和私钥中的空格和换行
         $("#alipay_public_key,#alipay_private_key,#f2fpay_public_key,#f2fpay_private_key").on('input', function () {
             $(this).val($(this).val().replace(/(\s+)/g, ''));
         });
+
+        // 设置f2fpay的商品名称
+        function setF2fpaySubjectName() {
+            var f2fpay_subject_name = $("#f2fpay_subject_name").val();
+
+            $.post("{{url('admin/setConfig')}}", {
+                _token: '{{csrf_token()}}',
+                name: 'f2fpay_subject_name',
+                value: f2fpay_subject_name
+            }, function (ret) {
+                layer.msg(ret.message, {time: 1000}, function () {
+                    if (ret.status == 'fail') {
+                        window.location.reload();
+                    }
+                });
+            });
+        }
 
         // 设置最小积分
         $("#min_rand_traffic").change(function () {

--- a/sql/update/20190317.sql
+++ b/sql/update/20190317.sql
@@ -1,2 +1,2 @@
--- 节点适配rico93版的v2ray插件
+-- 增加F2FPay自定义商品名选项
 INSERT INTO `config` VALUES ('89', 'f2fpay_subject_name', '');

--- a/sql/update/20190317.sql
+++ b/sql/update/20190317.sql
@@ -1,0 +1,2 @@
+-- 节点适配rico93版的v2ray插件
+INSERT INTO `config` VALUES ('89', 'f2fpay_subject_name', '');


### PR DESCRIPTION
关于数据库变动，增加了以下字段
①
数据表：config；
ID：89；
配置名：f2fpay_subject_name；
配置值：默认为空。
————————————————
问题原因：Kitsunebi不支持无缩进json。
由自己机场用户反馈，未测试问题广泛性。